### PR TITLE
Update to current APIs, cleaning of warnings and name as parameter

### DIFF
--- a/Chapter_06/Composing/Api.bicep
+++ b/Chapter_06/Composing/Api.bicep
@@ -14,7 +14,7 @@ var appConfigurationReaderRoleId = '516239f1-63e1-4d78-a4de-a74fb236a071' // RBA
 // The variable below is part of the translation from ARM to Bicep, but no longer needed
 // as the switch from linked deploments to Bicep modules, makes staging the resource 
 // templates unnecessary. It is left in for reference only.
-var templateBasePath = '${templateSettings.storageAccountUrl}/${templateSettings.storageContainer}'
+
 
 
 module applicationInsightsModule '../Resources/Insights/ApplicationInsights.bicep' = {
@@ -62,6 +62,7 @@ resource SecretReaderResource 'Microsoft.Authorization/roleAssignments@2022-04-0
   scope: kv
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretReaderRoleId)
+    principalType: 'ServicePrincipal'
     principalId: webAppModule.outputs.principalId
   }
 }
@@ -75,6 +76,7 @@ resource ConfigurationReaderResource 'Microsoft.Authorization/roleAssignments@20
   scope: appConfiguration
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', appConfigurationReaderRoleId)
+    principalType: 'ServicePrincipal'
     principalId: webAppModule.outputs.principalId
   }
 }

--- a/Chapter_06/Composing/Api.bicep
+++ b/Chapter_06/Composing/Api.bicep
@@ -67,7 +67,7 @@ resource SecretReaderResource 'Microsoft.Authorization/roleAssignments@2022-04-0
   }
 }
 
-resource appConfiguration 'Microsoft.AppConfiguration/configurationStores@2019-11-01-preview' existing = {
+resource appConfiguration 'Microsoft.AppConfiguration/configurationStores@2022-05-01' existing = {
   name: appConfigurationName
 }
 

--- a/Chapter_06/Composing/Api.bicep
+++ b/Chapter_06/Composing/Api.bicep
@@ -1,13 +1,14 @@
 param env string
+param sufix string
 param appServicePlanSku object
 param keyVaultName string
 param appConfigurationName string
 param templateSettings object
 
-var logAnalyticsWorkspaceName = 'log-bookdemo-${env}'
-var appInsightsName = 'appi-bookdemo-${env}'
-var webAppName = 'app-bookdemo-${env}'
-var webAppNamePlan = 'plan-bookdemo-${env}'
+var logAnalyticsWorkspaceName = 'log-${sufix}-${env}'  
+var appInsightsName = 'appi-${sufix}-${env}'
+var webAppName = 'app-${sufix}-${env}'
+var webAppNamePlan = 'plan-${sufix}-${env}'
 var keyVaultSecretReaderRoleId = '4633458b-17de-408a-b874-0445c86b69e6' // RBAC Role: Key Vault Secrets User
 var appConfigurationReaderRoleId = '516239f1-63e1-4d78-a4de-a74fb236a071' // RBAC Role: App Configuration Data Reader
 

--- a/Chapter_06/Composing/Api.bicep
+++ b/Chapter_06/Composing/Api.bicep
@@ -12,12 +12,6 @@ var webAppNamePlan = 'plan-${sufix}-${env}'
 var keyVaultSecretReaderRoleId = '4633458b-17de-408a-b874-0445c86b69e6' // RBAC Role: Key Vault Secrets User
 var appConfigurationReaderRoleId = '516239f1-63e1-4d78-a4de-a74fb236a071' // RBAC Role: App Configuration Data Reader
 
-// The variable below is part of the translation from ARM to Bicep, but no longer needed
-// as the switch from linked deploments to Bicep modules, makes staging the resource 
-// templates unnecessary. It is left in for reference only.
-
-
-
 module applicationInsightsModule '../Resources/Insights/ApplicationInsights.bicep' = {
   name: 'applicationInsightsModule'
   params: {

--- a/Chapter_06/Composing/Configuration.bicep
+++ b/Chapter_06/Composing/Configuration.bicep
@@ -5,7 +5,7 @@ param templateSettings object
 // The variable below is part of the translation from ARM to Bicep, but no longer needed
 // as the switch from linked deploments to Bicep modules, makes staging the resource 
 // templates unnecessary. It is left in for reference only.
-var templateBasePath = '${templateSettings.storageAccountUrl}/${templateSettings.storageContainer}'
+
 
 module keyVaultModule '../Resources/Keyvault/KeyVault.bicep' = {
   name: 'keyVaultModule'

--- a/Chapter_06/Composing/Configuration.bicep
+++ b/Chapter_06/Composing/Configuration.bicep
@@ -2,11 +2,6 @@ param keyVaultName string
 param appConfigurationName string
 param templateSettings object
 
-// The variable below is part of the translation from ARM to Bicep, but no longer needed
-// as the switch from linked deploments to Bicep modules, makes staging the resource 
-// templates unnecessary. It is left in for reference only.
-
-
 module keyVaultModule '../Resources/Keyvault/KeyVault.bicep' = {
   name: 'keyVaultModule'
   params: {

--- a/Chapter_06/Composing/Main.bicep
+++ b/Chapter_06/Composing/Main.bicep
@@ -4,7 +4,7 @@ param sqlSettings object
 param storageAccountSettings array
 param templateSettings object
 
-var keyVaultName = 'kv-bookdemoern21-${env}'
+var keyVaultName = 'kv-bookdemoern24-${env}'
 var appConfigurationName = 'appconfig-bookdemo-${env}'
 
 module configurationModule './Configuration.bicep' = {

--- a/Chapter_06/Composing/Main.bicep
+++ b/Chapter_06/Composing/Main.bicep
@@ -4,7 +4,7 @@ param sqlSettings object
 param storageAccountSettings array
 param templateSettings object
 
-var keyVaultName = 'kv-bookdemoern24-${env}'
+var keyVaultName = 'kv-bookdemoern26-${env}'
 var appConfigurationName = 'appconfig-bookdemo-${env}'
 
 module configurationModule './Configuration.bicep' = {

--- a/Chapter_06/Composing/Main.bicep
+++ b/Chapter_06/Composing/Main.bicep
@@ -1,11 +1,12 @@
 param env string
+param sufix string 
 param appServicePlanSku object
 param sqlSettings object
 param storageAccountSettings array
 param templateSettings object
 
-var keyVaultName = 'kv-bookdemoern26-${env}'
-var appConfigurationName = 'appconfig-bookdemo-${env}'
+var keyVaultName = 'kv-${sufix}-${env}'
+var appConfigurationName = 'appconfig-${sufix}-${env}'
 
 module configurationModule './Configuration.bicep' = {
   name: 'configurationModule'
@@ -23,6 +24,7 @@ module apiModule './Api.bicep' = {
   ]
   params: {
     env: env
+    sufix: sufix
     appServicePlanSku: appServicePlanSku
     keyVaultName: keyVaultName
     appConfigurationName: appConfigurationName
@@ -37,6 +39,7 @@ module storageModule './Storage.bicep' = {
   ]
   params: {
     env: env
+    sufix: sufix
     keyVaultName: keyVaultName
     sqlSettings: sqlSettings
     storageAccountSettings: storageAccountSettings

--- a/Chapter_06/Composing/Main.bicep
+++ b/Chapter_06/Composing/Main.bicep
@@ -4,7 +4,7 @@ param sqlSettings object
 param storageAccountSettings array
 param templateSettings object
 
-var keyVaultName = 'kv-bookdemo-${env}'
+var keyVaultName = 'kv-bookdemoern19-${env}'
 var appConfigurationName = 'appconfig-bookdemo-${env}'
 
 module configurationModule './Configuration.bicep' = {

--- a/Chapter_06/Composing/Main.bicep
+++ b/Chapter_06/Composing/Main.bicep
@@ -4,7 +4,7 @@ param sqlSettings object
 param storageAccountSettings array
 param templateSettings object
 
-var keyVaultName = 'kv-bookdemoern19-${env}'
+var keyVaultName = 'kv-bookdemoern21-${env}'
 var appConfigurationName = 'appconfig-bookdemo-${env}'
 
 module configurationModule './Configuration.bicep' = {

--- a/Chapter_06/Composing/Main.parameters.test.json
+++ b/Chapter_06/Composing/Main.parameters.test.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "env": {
-            "value": "dev"
+            "value": "uat"
         },
         "appServicePlanSku": {
             "value": {

--- a/Chapter_06/Composing/Main.parameters.test.json
+++ b/Chapter_06/Composing/Main.parameters.test.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "env": {
-            "value": "uat"
+            "value": "tst"
         },
         "appServicePlanSku": {
             "value": {

--- a/Chapter_06/Composing/Main.parameters.test.json
+++ b/Chapter_06/Composing/Main.parameters.test.json
@@ -3,10 +3,10 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "env": {
-            "value": "sta"
+            "value": "testhb"
         },
         "sufix": {
-            "value": "ernbookprueba27"
+            "value": "bookdemo"
         },        
         "appServicePlanSku": {
             "value": {

--- a/Chapter_06/Composing/Main.parameters.test.json
+++ b/Chapter_06/Composing/Main.parameters.test.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "env": {
-            "value": "tst"
+            "value": "sta"
         },
         "appServicePlanSku": {
             "value": {

--- a/Chapter_06/Composing/Main.parameters.test.json
+++ b/Chapter_06/Composing/Main.parameters.test.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "env": {
-            "value": "testhb"
+            "value": "dev"
         },
         "appServicePlanSku": {
             "value": {
@@ -45,7 +45,7 @@
         },
         "templateSettings": {
             "value": {
-                "location": "westeurope",
+                "location": "eastus2",
                 "storageAccountUrl": "nolongerusedinbicep",
                 "storageContainer": "storageContainer"
             }

--- a/Chapter_06/Composing/Main.parameters.test.json
+++ b/Chapter_06/Composing/Main.parameters.test.json
@@ -48,7 +48,7 @@
         },
         "templateSettings": {
             "value": {
-                "location": "eastus2",
+                "location": "westeurope",
                 "storageAccountUrl": "nolongerusedinbicep",
                 "storageContainer": "storageContainer"
             }

--- a/Chapter_06/Composing/Main.parameters.test.json
+++ b/Chapter_06/Composing/Main.parameters.test.json
@@ -5,6 +5,9 @@
         "env": {
             "value": "sta"
         },
+        "sufix": {
+            "value": "ernbookprueba27"
+        },        
         "appServicePlanSku": {
             "value": {
                 "capacity": 1,

--- a/Chapter_06/Composing/Storage.bicep
+++ b/Chapter_06/Composing/Storage.bicep
@@ -1,11 +1,12 @@
 param env string
+param sufix string
 param keyVaultName string
 param sqlSettings object
 param storageAccountSettings array
 param templateSettings object
 
-var sqlServerName = 'sql-bookdemo-${env}'
-var SqlDatabaseName = 'sql-bookdemo-${env}'
+var sqlServerName = 'sql-${sufix}-${env}'
+var SqlDatabaseName = 'sql-${sufix}-${env}'
 
 // The variable below is part of the translation from ARM to Bicep, but no longer needed
 // as the switch from linked deploments to Bicep modules, makes staging the resource 

--- a/Chapter_06/Composing/Storage.bicep
+++ b/Chapter_06/Composing/Storage.bicep
@@ -10,7 +10,6 @@ var SqlDatabaseName = 'sql-bookdemo-${env}'
 // The variable below is part of the translation from ARM to Bicep, but no longer needed
 // as the switch from linked deploments to Bicep modules, makes staging the resource 
 // templates unnecessary. It is left in for reference only.
-var templateBasePath = '${templateSettings.storageAccountUrl}/${templateSettings.storageContainer}'
 
 module storageAccountModules '../Resources/Storage/StorageAccountV2.bicep' = [for storageAccountSetting in storageAccountSettings: {
   name: 'storageAccountModule-${storageAccountSetting.name}'

--- a/Chapter_06/Composing/Storage.bicep
+++ b/Chapter_06/Composing/Storage.bicep
@@ -8,10 +8,6 @@ param templateSettings object
 var sqlServerName = 'sql-${sufix}-${env}'
 var SqlDatabaseName = 'sql-${sufix}-${env}'
 
-// The variable below is part of the translation from ARM to Bicep, but no longer needed
-// as the switch from linked deploments to Bicep modules, makes staging the resource 
-// templates unnecessary. It is left in for reference only.
-
 module storageAccountModules '../Resources/Storage/StorageAccountV2.bicep' = [for storageAccountSetting in storageAccountSettings: {
   name: 'storageAccountModule-${storageAccountSetting.name}'
   params: {

--- a/Chapter_06/Resources/AppConfiguration/AppConfiguration.bicep
+++ b/Chapter_06/Resources/AppConfiguration/AppConfiguration.bicep
@@ -1,5 +1,5 @@
 param appConfigurationName string
-param skuName string = 'free'
+param skuName string = 'standard'
 param location string
 
 resource configurationStore 'Microsoft.AppConfiguration/configurationStores@2019-11-01-preview' = {

--- a/Chapter_06/Resources/AppConfiguration/AppConfiguration.bicep
+++ b/Chapter_06/Resources/AppConfiguration/AppConfiguration.bicep
@@ -2,7 +2,7 @@ param appConfigurationName string
 param skuName string = 'standard'
 param location string
 
-resource configurationStore 'Microsoft.AppConfiguration/configurationStores@2019-11-01-preview' = {
+resource configurationStore 'Microsoft.AppConfiguration/configurationStores@2022-05-01' = {
   name: appConfigurationName
   location: location
   sku: {

--- a/Chapter_06/Resources/AppConfiguration/AppConfiguration.bicep
+++ b/Chapter_06/Resources/AppConfiguration/AppConfiguration.bicep
@@ -1,5 +1,5 @@
 param appConfigurationName string
-param skuName string = 'standard'
+param skuName string = 'free'
 param location string
 
 resource configurationStore 'Microsoft.AppConfiguration/configurationStores@2022-05-01' = {

--- a/Chapter_06/Resources/Insights/ApplicationInsights.bicep
+++ b/Chapter_06/Resources/Insights/ApplicationInsights.bicep
@@ -5,9 +5,6 @@ param location string
 resource applicationInsightsResource 'Microsoft.Insights/components@2020-02-02-preview' = {
   name: applicationInsightsName
   kind: 'web'
-  dependsOn: [
-    omsWorkspaceResource
-  ]
   location: location
   properties: {
     Application_Type: 'web'
@@ -22,7 +19,7 @@ resource omsWorkspaceResource 'Microsoft.OperationalInsights/workspaces@2020-08-
         sku: {
             name: 'PerGB2018'
         }
-        retentionInDays: 30
+        retentionInDays: 60
         workspaceCapping: {
             dailyQuotaGb: -1
         }

--- a/Chapter_06/Resources/Insights/ApplicationInsights.bicep
+++ b/Chapter_06/Resources/Insights/ApplicationInsights.bicep
@@ -2,7 +2,7 @@ param applicationInsightsName string
 param logAnalyticsWorkspaceName string
 param location string
 
-resource applicationInsightsResource 'Microsoft.Insights/components@2020-02-02-preview' = {
+resource applicationInsightsResource 'Microsoft.Insights/components@2020-02-02' = {
   name: applicationInsightsName
   kind: 'web'
   location: location

--- a/Chapter_06/Resources/Insights/ApplicationInsights.bicep
+++ b/Chapter_06/Resources/Insights/ApplicationInsights.bicep
@@ -19,7 +19,7 @@ resource omsWorkspaceResource 'Microsoft.OperationalInsights/workspaces@2020-08-
         sku: {
             name: 'PerGB2018'
         }
-        retentionInDays: 60
+        retentionInDays: 30
         workspaceCapping: {
             dailyQuotaGb: -1
         }

--- a/Chapter_06/Resources/Insights/ApplicationInsights.bicep
+++ b/Chapter_06/Resources/Insights/ApplicationInsights.bicep
@@ -10,7 +10,7 @@ resource applicationInsightsResource 'Microsoft.Insights/components@2020-02-02-p
   ]
   location: location
   properties: {
-    applicationId: applicationInsightsName
+    Application_Type: 'web'
     WorkspaceResourceId: omsWorkspaceResource.id
   }
 }

--- a/Chapter_06/Resources/KeyVault/KeyVault.bicep
+++ b/Chapter_06/Resources/KeyVault/KeyVault.bicep
@@ -1,7 +1,7 @@
 param keyVaultName string
 param location string
 
-resource keyVaultResource 'Microsoft.KeyVault/vaults@2020-04-01-preview' = {
+resource keyVaultResource 'Microsoft.KeyVault/vaults@2022-07-01' = {
   name: keyVaultName
   location: location
   properties: {

--- a/Chapter_06/Resources/Sql/SqlServer.bicep
+++ b/Chapter_06/Resources/Sql/SqlServer.bicep
@@ -4,7 +4,7 @@ param sqlServerUsername string
 param sqlServerPassword string
 param location string
 
-resource mySqlServerResource 'Microsoft.Sql/servers@2015-05-01-preview' = {
+resource mySqlServerResource 'Microsoft.Sql/servers@2022-05-01-preview' = {
   name: name
   location: location
   properties: {

--- a/Chapter_06/Resources/Sql/SqlServerDatabase.bicep
+++ b/Chapter_06/Resources/Sql/SqlServerDatabase.bicep
@@ -3,7 +3,7 @@ param databaseSettings object
 param sqlServerName string
 param location string
 
-resource databaseResource 'Microsoft.Sql/servers/databases@2017-10-01-preview' = {
+resource databaseResource 'Microsoft.Sql/servers/databases@2022-05-01-preview' = {
   name: '${sqlServerName}/${name}'
   location: location
   sku: {

--- a/Chapter_06/Resources/Storage/StorageAccountV2.bicep
+++ b/Chapter_06/Resources/Storage/StorageAccountV2.bicep
@@ -3,7 +3,7 @@ param env string
 param keyVaultName string
 param location string
 
-resource myStorageAccountResource 'Microsoft.Storage/storageAccounts@2019-04-01' = {
+resource myStorageAccountResource 'Microsoft.Storage/storageAccounts@2022-05-01' = {
   name: 'stor${storageAccount.name}${env}'
   sku: {
     name: storageAccount.sku.name

--- a/Chapter_06/Resources/Storage/StorageAccountV2.bicep
+++ b/Chapter_06/Resources/Storage/StorageAccountV2.bicep
@@ -7,7 +7,7 @@ resource myStorageAccountResource 'Microsoft.Storage/storageAccounts@2019-04-01'
   name: 'stor${storageAccount.name}${env}'
   sku: {
     name: storageAccount.sku.name
-    tier: storageAccount.sku.tier
+
   }
   kind: 'StorageV2'
   location: location

--- a/Chapter_06/Resources/WebApp/Serverfarm.bicep
+++ b/Chapter_06/Resources/WebApp/Serverfarm.bicep
@@ -2,7 +2,7 @@ param name string
 param sku object
 param location string
 
-resource myServerFarmResource 'Microsoft.Web/serverfarms@2015-08-01' = {
+resource myServerFarmResource 'Microsoft.Web/serverfarms@2022-03-01' = {
   name: name
   kind: 'linux'
   location: location
@@ -11,9 +11,6 @@ resource myServerFarmResource 'Microsoft.Web/serverfarms@2015-08-01' = {
     capacity: sku.capacity
   }
   properties: {
-    name: name
-    workerSizeId: '1'
-    reserved: true
-    numberOfWorkers: 1
+    reserved: true    
   }
 }

--- a/Chapter_06/Resources/WebApp/WebApp.bicep
+++ b/Chapter_06/Resources/WebApp/WebApp.bicep
@@ -4,7 +4,7 @@ param linuxFxVersion string = 'DOTNETCORE|3.1'
 param appSettings array
 param location string
 
-resource webAppResource 'Microsoft.Web/sites@2018-02-01' = {
+resource webAppResource 'Microsoft.Web/sites@2022-03-01' = {
   name: webAppName
   location: location
   kind: 'app,linux'

--- a/Chapter_07/pipelines/single-job-resource-deployment-ppl.yml
+++ b/Chapter_07/pipelines/single-job-resource-deployment-ppl.yml
@@ -9,7 +9,7 @@ variables:
   azureServiceConnection: 'scAzureSponsorshipForBicep'
   resourceGroupName: 'exampleRG'
   location: 'westeurope'
-  templateFile: './Chapter_07/deployment/main.bicep'
+  templateFile: './deployment/main.bicep'
 pool:
   vmImage: $(vmImageName)
 
@@ -30,5 +30,5 @@ jobs:
           location: '$(location)'
           templateLocation: "Linked artifact"
           csmFile: '$(templateFile)'
-          csmParametersFile: "./Chapter_07/deployment/test.parameters.json"
+          csmParametersFile: "./deployment/test.parameters.json"
           deploymentMode: "Incremental"

--- a/Chapter_07/pipelines/single-job-resource-deployment-ppl.yml
+++ b/Chapter_07/pipelines/single-job-resource-deployment-ppl.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       #- bash: az bicep build --file ./deployment/main.bicep
       #  displayName: "Transpile Bicep"
-      - bash: ls
-        displayName: "Lista componentes"
 
       - task: AzureResourceManagerTemplateDeployment@3
         displayName: Deploy Main Template

--- a/Chapter_07/pipelines/single-job-resource-deployment-ppl.yml
+++ b/Chapter_07/pipelines/single-job-resource-deployment-ppl.yml
@@ -1,32 +1,20 @@
 trigger:
-- master
-
-name: Deploy Bicep files
-
-variables:
-  vmImageName: 'ubuntu-latest'
-
-  azureServiceConnection: 'scAzureSponsorshipForBicep'
-  resourceGroupName: 'exampleRG'
-  location: 'westeurope'
-  templateFile: './deployment/main.bicep'
-pool:
-  vmImage: $(vmImageName)
+  - main
 
 jobs:
   - job: publishbicep
     displayName: Publish bicep files as pipeline artifacts
     steps:
-      #- bash: az bicep build --file ./deployment/main.bicep
-      #  displayName: "Transpile Bicep"
+      - bash: az bicep build --file ./deployment/main.bicep
+        displayName: "Transpile Bicep"
 
       - task: AzureResourceManagerTemplateDeployment@3
         displayName: Deploy Main Template
         inputs:
-          azureResourceManagerConnection: '$(azureServiceConnection)'
+          azureResourceManagerConnection: "TestEnvironment"
           deploymentScope: "Subscription"
-          location: '$(location)'
+          location: "westeurope"
           templateLocation: "Linked artifact"
-          csmFile: '$(templateFile)'
+          csmFile: "./deployment/main.json"
           csmParametersFile: "./deployment/test.parameters.json"
           deploymentMode: "Incremental"

--- a/Chapter_07/pipelines/single-job-resource-deployment-ppl.yml
+++ b/Chapter_07/pipelines/single-job-resource-deployment-ppl.yml
@@ -1,20 +1,32 @@
 trigger:
-  - main
+- master
+
+name: Deploy Bicep files
+
+variables:
+  vmImageName: 'ubuntu-latest'
+
+  azureServiceConnection: 'scAzureSponsorshipForBicep'
+  resourceGroupName: 'exampleRG'
+  location: 'westeurope'
+  templateFile: './deployment/main.bicep'
+pool:
+  vmImage: $(vmImageName)
 
 jobs:
   - job: publishbicep
     displayName: Publish bicep files as pipeline artifacts
     steps:
-      - bash: az bicep build --file ./deployment/main.bicep
-        displayName: "Transpile Bicep"
+      #- bash: az bicep build --file ./deployment/main.bicep
+      #  displayName: "Transpile Bicep"
 
       - task: AzureResourceManagerTemplateDeployment@3
         displayName: Deploy Main Template
         inputs:
-          azureResourceManagerConnection: "TestEnvironment"
+          azureResourceManagerConnection: '$(azureServiceConnection)'
           deploymentScope: "Subscription"
-          location: "westeurope"
+          location: '$(location)'
           templateLocation: "Linked artifact"
-          csmFile: "./deployment/main.json"
+          csmFile: '$(templateFile)'
           csmParametersFile: "./deployment/test.parameters.json"
           deploymentMode: "Incremental"

--- a/Chapter_07/pipelines/single-job-resource-deployment-ppl.yml
+++ b/Chapter_07/pipelines/single-job-resource-deployment-ppl.yml
@@ -9,7 +9,7 @@ variables:
   azureServiceConnection: 'scAzureSponsorshipForBicep'
   resourceGroupName: 'exampleRG'
   location: 'westeurope'
-  templateFile: './deployment/main.bicep'
+  templateFile: './Chapter_07/deployment/main.bicep'
 pool:
   vmImage: $(vmImageName)
 
@@ -30,5 +30,5 @@ jobs:
           location: '$(location)'
           templateLocation: "Linked artifact"
           csmFile: '$(templateFile)'
-          csmParametersFile: "./deployment/test.parameters.json"
+          csmParametersFile: "./Chapter_07/deployment/test.parameters.json"
           deploymentMode: "Incremental"

--- a/Chapter_07/pipelines/single-job-resource-deployment-ppl.yml
+++ b/Chapter_07/pipelines/single-job-resource-deployment-ppl.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       #- bash: az bicep build --file ./deployment/main.bicep
       #  displayName: "Transpile Bicep"
+      - bash: ls
+        displayName: "Lista componentes"
 
       - task: AzureResourceManagerTemplateDeployment@3
         displayName: Deploy Main Template


### PR DESCRIPTION
After fixing Api.Bicep with the inclussion of "principalType: 'ServicePrincipal'" the deployment worked ok, but I tried to clean the unneeded parameters and update to the latest version of APIs, also I removed all the warnings and added the parameter "sufix" in order to make easier the name customization, reducing the chances of getting duplicated resources in Azure.

Hope it helps, thanks!